### PR TITLE
Refactor/disable next button

### DIFF
--- a/src/components/stepper/Stepper.tsx
+++ b/src/components/stepper/Stepper.tsx
@@ -106,7 +106,7 @@ const Stepper = () => {
           {arr}
         </ProgressBar>
         {/* Render step-specific content */}
-        <Steps number={active} setCakeValues={setCakeValues} />
+        <Steps stepNumber={active} setCakeValues={setCakeValues} />
       </Content>
       {/* Navigation buttons */}
       <ButtonsContainer>

--- a/src/components/stepper/Stepper.tsx
+++ b/src/components/stepper/Stepper.tsx
@@ -75,6 +75,7 @@ const Stepper = () => {
   const [circle] = useState(5); // Total number of steps
   const [active, setActive] = useState(0); // Current active step
   const [width, setWidth] = useState(0);
+  const [disableNextButton, setDisableNextButton] = useState(false);
 
   // Function to update values in the Stepper component
   const setCakeValues = (values: number) => {
@@ -106,7 +107,11 @@ const Stepper = () => {
           {arr}
         </ProgressBar>
         {/* Render step-specific content */}
-        <Steps stepNumber={active} setCakeValues={setCakeValues} />
+        <Steps
+          stepNumber={active}
+          setCakeValues={setCakeValues}
+          setDisableNextButton={setDisableNextButton}
+        />
       </Content>
       {/* Navigation buttons */}
       <ButtonsContainer>
@@ -121,7 +126,7 @@ const Stepper = () => {
         />
         <Button
           name="next"
-          disabled={active >= circle - 1}
+          disabled={active >= circle - 1 || disableNextButton}
           onClick={() => {
             if (active >= circle - 1) {
               setActive(circle - 1);

--- a/src/components/steps/Steps.tsx
+++ b/src/components/steps/Steps.tsx
@@ -53,9 +53,14 @@ const SliderLabel = styled.label`
 interface StepsProps {
   stepNumber: number;
   setCakeValues: (values: any) => void;
+  setDisableNextButton: (isDisabled: boolean) => void;
 }
 
-const Steps: React.FC<StepsProps> = ({ stepNumber, setCakeValues }) => {
+const Steps: React.FC<StepsProps> = ({
+  stepNumber,
+  setCakeValues,
+  setDisableNextButton,
+}) => {
   // These values are strings so that the entire input can be deleted.
   const [howManyPortions, setHowManyPortions] = useState("6");
   const [cakesHigh, setCakesHigh] = useState("7");
@@ -70,9 +75,13 @@ const Steps: React.FC<StepsProps> = ({ stepNumber, setCakeValues }) => {
     switch (id) {
       case "portions-count":
         setHowManyPortions(value);
+        // Disable button when the user enters less than 6 in the input.
+        setDisableNextButton(parseInt(value, 10) < 6);
         break;
       case "cakes-high":
         setCakesHigh(value);
+        // Disable button when the user enters less than 7 in the input.
+        setDisableNextButton(parseInt(value, 10) < 7);
         break;
       case "price-per-portion":
         setPricePerOnePerson(value);
@@ -173,6 +182,9 @@ const Steps: React.FC<StepsProps> = ({ stepNumber, setCakeValues }) => {
           />
         </>
       );
+      break;
+    default:
+      break;
   }
 
   return <StepContainer>{step}</StepContainer>;

--- a/src/components/steps/Steps.tsx
+++ b/src/components/steps/Steps.tsx
@@ -51,11 +51,11 @@ const SliderLabel = styled.label`
 `;
 
 interface StepsProps {
-  number: number;
+  stepNumber: number;
   setCakeValues: (values: any) => void;
 }
 
-const Steps: React.FC<StepsProps> = ({ number, setCakeValues }) => {
+const Steps: React.FC<StepsProps> = ({ stepNumber, setCakeValues }) => {
   // These values are strings so that the entire input can be deleted.
   const [howManyPortions, setHowManyPortions] = useState("6");
   const [cakesHigh, setCakesHigh] = useState("7");
@@ -98,7 +98,7 @@ const Steps: React.FC<StepsProps> = ({ number, setCakeValues }) => {
 
   // Logic to render different steps based on the 'number' prop
   let step;
-  switch (number) {
+  switch (stepNumber) {
     case 0:
       step = (
         <>


### PR DESCRIPTION
- Added setDisableNextButton prop to Steps: Enabled passing disable info for the nextButton from Steps to Stepper.
-  Updated handleInputChange in Steps to adjust setDisableNextButton based on input value (<6 in 'portions-count' case and <7 in 'cakes-high' case).
These changes introduce validation for inputs, preventing the user from advancing to the next step if the above conditions are not met.