### PR TITLE
refactor(style-updates): Hide arrows for input

### DIFF
--- a/src/components/steps/Steps.tsx
+++ b/src/components/steps/Steps.tsx
@@ -49,7 +49,16 @@ const InputField = styled.input`
     cursor: pointer;
   }
   &:focus {
-    border: solid 2px ${theme.colors.input};
+    border: solid 2px ${theme.colors.black};
+  }
+  /* Hide arrows for input */
+  &[type="number"]::-webkit-inner-spin-button,
+  &[type="number"]::-webkit-outer-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
+  &[type="number"] {
+    -moz-appearance: textfield; /* Firefox */
   }
   ${theme.mixin.forMinWidth650(`
     top: 385px;

--- a/src/styles/theme.tsx
+++ b/src/styles/theme.tsx
@@ -40,7 +40,6 @@ const colors = {
   disabledButton: "#575757",
   white: "#ffffff",
   black: "#000000",
-  input: "#464141",
   yellow: "#F9D644",
   pink: "#F88B9E",
   lightPink: "#F8A4B3",


### PR DESCRIPTION
Removed default number input arrows from the InputField component, enhancing its visual consistency and user experience. The changes ensure a cleaner appearance while retaining existing styling and functionality.