### PR TITLE
fix(step-header-0-mobile): Fix step header

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -13,7 +13,7 @@
       "cakeDiameter": "diameter"
     },
     "steps": {
-      "0": "How many guests will the cake serve?",
+      "0": "How many guests?",
       "1": "Cake height in cm:",
       "2": "Set the price per person:",
       "3": "Set the deposit percentage"


### PR DESCRIPTION
Fixed step header in the first step in English locales mobile version. Step header overlapped on input. Header content adjusted, more precisely shortened ("How many guests?").