### PR TITLE
refactor(Button): Rename 'name' prop to 'type' in Button component

### DIFF
--- a/src/components/button/Button.test.tsx
+++ b/src/components/button/Button.test.tsx
@@ -2,24 +2,24 @@ import { render } from "@testing-library/react";
 import ButtonComponent from "./Button";
 
 describe("ButtonComponent", () => {
-  it("renders StartButton when name is 'start', with 'start' string inside", () => {
+  it("renders StartButton when type is 'start', with 'start' string inside", () => {
     const handleClick = vi.fn();
     const startWrapper = render(
-      <ButtonComponent name="start" onClick={handleClick} />
+      <ButtonComponent type="start" onClick={handleClick} />
     );
     const startButton = startWrapper.getByText("start");
     expect(startButton).toBeVisible();
   });
 
-  it("renders NextButton when name is 'next', with 'next-button' test id and checks the text content", () => {
-    const nextWrapper = render(<ButtonComponent name="next" />);
+  it("renders NextButton when type is 'next', with 'next-button' test id and checks the text content", () => {
+    const nextWrapper = render(<ButtonComponent type="next" />);
     const nextButton = nextWrapper.getByTestId("next-button");
     expect(nextButton).toBeVisible();
     expect(nextButton).toHaveTextContent("button.next");
   });
 
-  it("renders NextButton when name is 'previous', with 'previous-button' test id and checks the text content", () => {
-    const previousWrapper = render(<ButtonComponent name="previous" />);
+  it("renders NextButton when type is 'previous', with 'previous-button' test id and checks the text content", () => {
+    const previousWrapper = render(<ButtonComponent type="previous" />);
     const previousButton = previousWrapper.getByTestId("previous-button");
     expect(previousButton).toBeVisible();
     expect(previousButton).toHaveTextContent("button.return");

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -6,7 +6,6 @@ import { useTranslation } from "react-i18next";
 const Button = styled.button`
   ${theme.mixin.defaultButton};
   text-align: center;
-  font-size: ${theme.fontSize.button_start};
   font-family: "Medium_BasisGrotesqueArabicPro";
   border-radius: 50px;
   padding: 12px 40px;
@@ -103,53 +102,47 @@ const PreviousButtonWrapper = styled.div`
 `;
 
 // Interface for button props
-interface IconProps {
-  name: "start" | "next" | "previous";
+interface ButtonProps {
+  type: "start" | "next" | "previous";
   onClick?: React.MouseEventHandler;
   disabled?: boolean;
 }
 
-// Button component with different variations based on the name prop
-const ButtonComponent: React.FC<IconProps> = ({ name, onClick, disabled }) => {
+// Button component with different variations based on the type prop
+const ButtonComponent: React.FC<ButtonProps> = ({
+  type,
+  onClick,
+  disabled,
+}) => {
   // Get the translation function 't' and the i18n instance from the useTranslation hook
   const { t } = useTranslation();
 
-  let button;
-
-  // Switch case to render different buttons based on the name prop
-  switch (name) {
-    case "start":
-      button = <StartButton onClick={onClick}>start</StartButton>;
-      break;
-    case "next":
-      button = (
-        <NextButton
-          data-testid="next-button"
+  // Switch case to render different buttons based on the type prop
+  const buttonTypes = {
+    start: <StartButton onClick={onClick}>start</StartButton>,
+    next: (
+      <NextButton
+        data-testid="next-button"
+        onClick={onClick}
+        disabled={disabled}
+      >
+        {t("button.next")}
+      </NextButton>
+    ),
+    previous: (
+      <PreviousButtonWrapper>
+        <PreviousButton
+          data-testid="previous-button"
           onClick={onClick}
           disabled={disabled}
         >
-          {t("button.next")}
-        </NextButton>
-      );
-      break;
-    case "previous":
-      button = (
-        <PreviousButtonWrapper>
-          <PreviousButton
-            data-testid="previous-button"
-            onClick={onClick}
-            disabled={disabled}
-          >
-            {t("button.return")}
-          </PreviousButton>
-        </PreviousButtonWrapper>
-      );
-      break;
-    default:
-      button = null;
-  }
+          {t("button.return")}
+        </PreviousButton>
+      </PreviousButtonWrapper>
+    ),
+  };
 
-  return button;
+  return buttonTypes[type] || null;
 };
 
 export default ButtonComponent;

--- a/src/components/stepper/Stepper.tsx
+++ b/src/components/stepper/Stepper.tsx
@@ -110,7 +110,7 @@ const Stepper: React.FC<StepperProps> = ({ isLastStep, setIsLastStep }) => {
       {/* Navigation buttons */}
       <ButtonsContainer data-testid="buttons-container">
         <Button
-          name="previous"
+          type="previous"
           data-testid="previous-button"
           disabled={active <= 0}
           onClick={() => {
@@ -120,7 +120,7 @@ const Stepper: React.FC<StepperProps> = ({ isLastStep, setIsLastStep }) => {
           }}
         />
         <Button
-          name="next"
+          type="next"
           data-testid="next-button"
           disabled={active >= totalSteps - 1 || disableNextButton}
           onClick={() => {

--- a/src/components/welcomePage/WelcomePage.test.tsx
+++ b/src/components/welcomePage/WelcomePage.test.tsx
@@ -36,6 +36,6 @@ describe("WelcomePage component", () => {
     setTimeout(() => {
       window.innerWidth = 1550;
       expect(welcomePage).toHaveStyle("flex-direction: row");
-    }, 20);
+    }, 30);
   });
 });

--- a/src/components/welcomePage/WelcomePage.tsx
+++ b/src/components/welcomePage/WelcomePage.tsx
@@ -69,7 +69,7 @@ const WelcomePage = ({ onStartClick }: WelcomePageProps) => {
         <Description data-testit="description">
           {t("welcomePage.description")}
         </Description>
-        <Button name="start" onClick={onStartClick} />
+        <Button type="start" onClick={onStartClick} />
       </CenterWrapper>
       <LightCakeIcon data-testid="light-cake-icon">
         <Icon name="lightCake" aria-label="cream cake with candles" />


### PR DESCRIPTION
This commit changes the 'name' prop in the Button component to 'type' for better clarity and understanding of its purpose. The 'type' prop now accepts values 'start', 'next', and 'previous' to render different types of buttons.